### PR TITLE
feat: add fallback textarea in noscript

### DIFF
--- a/templates/form/tinymce_type.html.twig
+++ b/templates/form/tinymce_type.html.twig
@@ -10,4 +10,12 @@
 		>{{ value }}</tinymce-editor>
 	<script src="{{ asset('bundles/tinymce/default-tinymce-config.js') }}" type="module"></script>
 	<script src="{{ asset('bundles/tinymce/ext/tinymce-webcomponent.js') }}" type="module"></script>
+	<noscript>
+		<textarea id="{{ id }}-noscript"
+			name="{{ full_name }}"
+			{{ required ? "required" : "" }}
+			{% with { attr: tinymce_attributes(attr) } %}
+				{{ block('attributes') }}
+			{% endwith %}>{{ value }}</textarea>
+	</noscript>
 {%- endblock -%}

--- a/tests/e2e/tests-noscript.spec.ts
+++ b/tests/e2e/tests-noscript.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+test.use({ javaScriptEnabled: false });
+
+test.describe('Without Javascript', () => {
+	test('Form type', async ({ page }) => {
+		await page.goto('http://localhost/test/form');
+
+		const textarea = page.getByRole('textbox').getByText('Initial text value');
+
+		// Validate fallback textarea is present and has initial content
+		await expect(textarea).toBeVisible();
+		await expect(textarea).toHaveValue('<p>Initial text value</p>');
+		// Update the content and submit the form
+		await textarea.fill('Initial text value has been updated!');
+		await page.getByRole('button', { name: 'Submit' }).click();
+
+		// Validate form data is received correctly
+		await expect(page.getByText('Initial text value has been updated!')).toBeVisible();
+	});
+});

--- a/tests/e2e/tests.spec.ts
+++ b/tests/e2e/tests.spec.ts
@@ -1,47 +1,49 @@
 import { test, expect } from '@playwright/test';
 
-test('Form type', async ({ page }) => {
-  await page.goto('http://localhost/test/form');
+test.describe('With Javascript', () => {
+	test('Form type', async ({ page }) => {
+		await page.goto('http://localhost/test/form');
 
-  // Validate initial content
-  await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
+		// Validate initial content
+		await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
 
-  // Validate YAML configuration-provided attribute
-  await expect(page.getByLabel('Bold')).toBeVisible();
+		// Validate YAML configuration-provided attribute
+		await expect(page.getByLabel('Bold')).toBeVisible();
 
-  // Validate user-provided attribute
-  await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
+		// Validate user-provided attribute
+		await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
 
-  // Update the content and submit the form
-  await page.frameLocator('iframe[title="Rich Text Area"]').getByLabel('Rich Text Area. Press ALT-0').fill('Initial text value has been updated!');
-  await page.getByRole('button', { name: 'Submit' }).click();
+		// Update the content and submit the form
+		await page.frameLocator('iframe[title="Rich Text Area"]').getByLabel('Rich Text Area. Press ALT-0').fill('Initial text value has been updated!');
+		await page.getByRole('button', { name: 'Submit' }).click();
 
-  // Validate form data is received correctly
-  await expect(page.getByText('Initial text value has been updated!')).toBeVisible();
-});
+		// Validate form data is received correctly
+		await expect(page.getByText('Initial text value has been updated!')).toBeVisible();
+	});
 
-test('Template', async ({ page }) => {
-  await page.goto('http://localhost/test/template');
+	test('Template', async ({ page }) => {
+		await page.goto('http://localhost/test/template');
 
-  // Validate initial content
-  await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
+		// Validate initial content
+		await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
 
-  // Validate YAML configuration-provided attribute
-  await expect(page.getByLabel('Bold')).toBeVisible();
+		// Validate YAML configuration-provided attribute
+		await expect(page.getByLabel('Bold')).toBeVisible();
 
-  // Validate user-provided attribute
-  await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
-});
+		// Validate user-provided attribute
+		await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
+	});
 
-test('Javascript', async ({ page }) => {
-  await page.goto('http://localhost/test/javascript');
+	test('Javascript', async ({ page }) => {
+		await page.goto('http://localhost/test/javascript');
 
-  // Validate initial content
-  await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
+		// Validate initial content
+		await expect(page.frameLocator('iframe[title="Rich Text Area"]').getByText('Initial text value')).toBeVisible();
 
-  // Validate YAML configuration-provided attribute
-  await expect(page.getByLabel('Bold')).toBeVisible();
+		// Validate YAML configuration-provided attribute
+		await expect(page.getByLabel('Bold')).toBeVisible();
 
-  // Validate user-provided attribute
-  await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
+		// Validate user-provided attribute
+		await expect(page.locator('button').filter({ hasText: 'Format' })).toBeVisible();
+	});
 });


### PR DESCRIPTION
This is an attempt at making this form type test-friendly for folks using testing suites that do not execute Javascript code.

Ex.: https://github.com/eckinox/tinymce-bundle/issues/18 