### PR TITLE
fix: hardcoded config variable name for default TinyMCE config

### DIFF
--- a/public/default-tinymce-config.js
+++ b/public/default-tinymce-config.js
@@ -1,5 +1,0 @@
-if (typeof window.tinymceAdditionalConfig === 'undefined') {
-	window.tinymceAdditionalConfig = {
-		license_key: 'gpl',
-	};
-}

--- a/src/Twig/TinymceTwigExtension.php
+++ b/src/Twig/TinymceTwigExtension.php
@@ -23,6 +23,7 @@ class TinymceTwigExtension extends AbstractExtension
             new TwigFunction('tinymce', [$this, 'tinymceEditor'], ['needs_environment' => true]),
             new TwigFunction('tinymce_scripts', [$this, 'tinymceScripts'], ['needs_environment' => true]),
             new TwigFunction('tinymce_attributes', [$this, 'tinymceAttributes']),
+            new TwigFunction('tinymce_config_variable_name', [$this, 'tinymceConfigVariableName']),
         ];
     }
 
@@ -69,5 +70,13 @@ class TinymceTwigExtension extends AbstractExtension
         ]);
 
         return new Markup($elementHtml, 'utf-8');
+    }
+
+    /**
+     * Returns the Javascript variable name for additional TinyMCE configurations.
+     */
+    public function tinymceConfigVariableName(): string
+    {
+        return $this->tinymceConfigurator->getGlobalAttributes()['config'] ?? 'tinymceAdditionalConfig';
     }
 }

--- a/templates/form/tinymce_type.html.twig
+++ b/templates/form/tinymce_type.html.twig
@@ -8,7 +8,7 @@
 		{% endwith %}
 		src="{{ asset('bundles/tinymce/ext/tinymce/tinymce.min.js') }}"
 		>{{ value }}</tinymce-editor>
-	<script src="{{ asset('bundles/tinymce/default-tinymce-config.js') }}" type="module"></script>
+	{% include '@Tinymce/partial/default_tinymce_config.html.twig' %}
 	<script src="{{ asset('bundles/tinymce/ext/tinymce-webcomponent.js') }}" type="module"></script>
 	<noscript>
 		<textarea id="{{ id }}-noscript"

--- a/templates/partial/default_tinymce_config.html.twig
+++ b/templates/partial/default_tinymce_config.html.twig
@@ -1,0 +1,7 @@
+<script type="module">
+	if (typeof window.{{ tinymce_config_variable_name() }} === 'undefined') {
+		window.{{ tinymce_config_variable_name() }} = {
+			license_key: 'gpl',
+		};
+	}
+</script>

--- a/templates/twig/tinymce_editor.html.twig
+++ b/templates/twig/tinymce_editor.html.twig
@@ -2,5 +2,5 @@
 	{{ attributes }}
 	src="{{ asset('bundles/tinymce/ext/tinymce/tinymce.min.js') }}"
 	>{{ data }}</tinymce-editor>
-<script src="{{ asset('bundles/tinymce/default-tinymce-config.js') }}" type="module"></script>
+{% include '@Tinymce/partial/default_tinymce_config.html.twig' %}
 <script src="{{ asset('bundles/tinymce/ext/tinymce-webcomponent.js') }}" type="module"></script>

--- a/templates/twig/tinymce_scripts.html.twig
+++ b/templates/twig/tinymce_scripts.html.twig
@@ -1,3 +1,3 @@
 <script src="{{ asset('bundles/tinymce/ext/tinymce/tinymce.min.js') }}"></script>
-<script src="{{ asset('bundles/tinymce/default-tinymce-config.js') }}" type="module"></script>
+{% include '@Tinymce/partial/default_tinymce_config.html.twig' %}
 <script src="{{ asset('bundles/tinymce/ext/tinymce-webcomponent.js') }}" type="module"></script>


### PR DESCRIPTION
The `default-tinymce-config.js` was relying on the additional config variable name being `tinymceAdditionalConfig`, but this variable name is configurable, so this wasn't always the case. 

When this variable name was different, the GPL license config wasn't applied, which caused unwanted "Upgrade" buttons to appear along with other TinyMCE Cloud version elements.

This MR updates the problematic behaviour to use the configured variable name instead of an hardcoded assumption.

closes #16 