### PR TITLE
fix: deprecation of `Symfony\Component\HttpKernel\DependencyInjection\Extension`

### DIFF
--- a/src/DependencyInjection/TinymceExtension.php
+++ b/src/DependencyInjection/TinymceExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension
 
 /**
  * This is the class that loads and manages your bundle configuration.

--- a/src/DependencyInjection/TinymceExtension.php
+++ b/src/DependencyInjection/TinymceExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\DependencyInjection\Extension\Extension
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.


### PR DESCRIPTION
Fixing deprecation notice:

```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be
deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further
notice. You should not use it from "EmilePerron\TinymceBundle\DependencyInjection\TinymceExtension".
```